### PR TITLE
fix!: Do not add trailing slash automatically

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,9 @@ else
 	if ! [[ $REDIRECT_TARGET =~ ^https?:// ]]; then
 		REDIRECT_TARGET="https://$REDIRECT_TARGET"
 	fi
+
+	# Remove trailing slash if present
+	REDIRECT_TARGET="${REDIRECT_TARGET%/}"
 fi
 
 # Default to 80

--- a/start.sh
+++ b/start.sh
@@ -7,11 +7,6 @@ else
 	if ! [[ $REDIRECT_TARGET =~ ^https?:// ]]; then
 		REDIRECT_TARGET="https://$REDIRECT_TARGET"
 	fi
-
-	# Add trailing slash
-	if [[ ${REDIRECT_TARGET:length-1:1} != "/" ]]; then
-		REDIRECT_TARGET="$REDIRECT_TARGET/"
-	fi
 fi
 
 # Default to 80
@@ -24,7 +19,7 @@ fi
 cat <<EOF > /etc/nginx/conf.d/default.conf
 server {
 	listen ${LISTEN};
-	rewrite ^/(.*)\$ ${REDIRECT_TARGET}\$1 permanent;
+	rewrite ^(.*)\$ ${REDIRECT_TARGET}\$1 permanent;
 }
 EOF
 

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,7 @@ fi
 cat <<EOF > /etc/nginx/conf.d/default.conf
 server {
 	listen ${LISTEN};
-	rewrite ^(.*)\$ ${REDIRECT_TARGET}\$1 permanent;
+	return 301 ${REDIRECT_TARGET}$request_uri;
 }
 EOF
 


### PR DESCRIPTION
## Current behavior
The app adds trailing slash to `REDIRECT_TARGET` automatically.

## The problem
There are no ways to access to the exact original URL.

## New behavior
The app uses `REDIRECT_TARGET` as-is.